### PR TITLE
Create action for adding the staging tag

### DIFF
--- a/.github/actions/add_staging_tag/action.yml
+++ b/.github/actions/add_staging_tag/action.yml
@@ -1,0 +1,24 @@
+name: 'Add staging tag'
+description: 'Add staging tag to current commit'
+runs:
+  using: "composite"
+  steps:
+    - name: Delete and re-create staging tag
+      uses: actions/github-script@v3
+      with:
+        script: |
+          try {
+              await github.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: "tags/staging"
+              })
+          } catch (e) {
+            console.log("The staging tag doesn't exist yet: " + e)
+          }
+          await github.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: "refs/tags/staging",
+            sha: context.sha
+          })


### PR DESCRIPTION
This creates a reusable action for adding the staging tag to the commit that it's called on. 
I already tested this in [this](https://github.com/lawpilots/lms-sso-service/actions/runs/1520992857) run. 