### PR TITLE
Add new PRs to github project

### DIFF
--- a/.github/workflows/assign_new_prs_to_project.yml
+++ b/.github/workflows/assign_new_prs_to_project.yml
@@ -1,0 +1,13 @@
+name: Auto-assign PRs and Issues to Github Project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign_to_project:
+    uses: lawpilots/actions/.github/workflows/assign_to_project.yml@main
+    secrets:
+      MY_GITHUB_TOKEN: ${{ secrets.ORGA_GITHUB_TOKEN }}


### PR DESCRIPTION
I guess the PRs from the actions repo itself should be added to the github project as well, right?