### PR TITLE
Use GH_PROJECT_URL as input from caller workflow

### DIFF
--- a/.github/workflows/assign_new_prs_to_project.yml
+++ b/.github/workflows/assign_new_prs_to_project.yml
@@ -11,3 +11,5 @@ jobs:
     uses: lawpilots/actions/.github/workflows/assign_to_project.yml@main
     secrets:
       MY_GITHUB_TOKEN: ${{ secrets.ORGA_GITHUB_TOKEN }}
+    with:
+      GH_PROJECT_URL: ${{ inputs.gh_project_url }}

--- a/.github/workflows/assign_new_prs_to_project.yml
+++ b/.github/workflows/assign_new_prs_to_project.yml
@@ -12,4 +12,4 @@ jobs:
     secrets:
       MY_GITHUB_TOKEN: ${{ secrets.ORGA_GITHUB_TOKEN }}
     with:
-      GH_PROJECT_URL: ${{ inputs.gh_project_url }}
+      GH_PROJECT_URL: https://github.com/orgs/lawpilots/projects/3

--- a/.github/workflows/assign_to_project.yml
+++ b/.github/workflows/assign_to_project.yml
@@ -5,6 +5,11 @@ on:
     secrets:
       MY_GITHUB_TOKEN:
         required: true
+    inputs:
+      GH_PROJECT_URL:
+        description: 'The URL of the GitHub project'
+        required: true
+        type: string
 
 jobs:
   assign_to_project:
@@ -14,7 +19,7 @@ jobs:
       - name: Assign new issues and new pull requests to project
         uses: srggrs/assign-one-project-github-action@1.2.1
         with:
-          project: 'https://github.com/orgs/lawpilots/projects/3'
+          project: ${{ inputs.GH_PROJECT_URL }}
           column_name: 'To do'
         env:
           MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}


### PR DESCRIPTION
With this changes we're aiming at accepting the GH project URL as an input coming from the caller workflow